### PR TITLE
Add secret to credentials hash

### DIFF
--- a/lib/omniauth/strategies/twitter-access-token.rb
+++ b/lib/omniauth/strategies/twitter-access-token.rb
@@ -48,8 +48,7 @@ module OmniAuth
       end
 
       credentials do
-        hash = {'token' => access_token.token}
-        hash
+        {'token' => access_token.token, 'secret' => access_token.secret}
       end
 
       def raw_info


### PR DESCRIPTION
Let's add `secret` to credentials hash in order to be compatible with the omniauth-twitter gem, which inherits this from https://github.com/intridea/omniauth-oauth/blob/master/lib/omniauth/strategies/oauth.rb#L72
